### PR TITLE
fix: Docker compose on Apple M1 Chip

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
   db:
     restart: always
     image: mysql:8.0.25
+    platform: linux/amd64
     ports:
       - "3306:3306"
     environment:


### PR DESCRIPTION
fix error: ERROR: no matching manifest for linux/arm64/v8 in the manifest list entries